### PR TITLE
Optimize throughput experiment

### DIFF
--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -2,7 +2,11 @@
 
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
@@ -11,13 +15,13 @@
     </appender>
 
     <logger name="com.softwaremill.bootzooka" level="DEBUG" additivity="false">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="ASYNC" />
     </logger>
 
     <!-- Strictly speaking, the level attribute is not necessary since -->
     <!-- the level of the root level is set to DEBUG by default.       -->
     <root level="INFO">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="ASYNC" />
     </root>
 
 </configuration>

--- a/backend/src/main/resources/reference.conf
+++ b/backend/src/main/resources/reference.conf
@@ -12,7 +12,7 @@ bootzooka {
     postgres {
       queueSize = -1
       dataSourceClass = "org.postgresql.ds.PGSimpleDataSource"
-      maxConnections = 16
+      maxConnections = 20
       properties = {
         serverName = ""
         portNumber = "5432"

--- a/backend/src/main/resources/reference.conf
+++ b/backend/src/main/resources/reference.conf
@@ -3,16 +3,19 @@ bootzooka {
 
   db {
     h2 {
-      queueSize = -1
+      queueSize = 3000
+      numThreads = 16
       dataSourceClass = "org.h2.jdbcx.JdbcDataSource"
       properties = {
         url = "jdbc:h2:file:./data/bootzooka"
       }
     }
     postgres {
-      queueSize = -1
+      queueSize = 3000
+      # intended to match maxConnections below
+      numThreads = 16
       dataSourceClass = "org.postgresql.ds.PGSimpleDataSource"
-      maxConnections = 20
+      maxConnections = 16
       properties = {
         serverName = ""
         portNumber = "5432"
@@ -47,7 +50,9 @@ akka.http.session {
   server-secret = ${?SERVER_SECRET}
 }
 
+# the below dispatchers are to bulkhead layers and also not use default dispatcher
 akka-http-routes-dispatcher {
+  # these are the default dispatcher settings
   type = "Dispatcher"
   executor = "fork-join-executor"
 
@@ -61,6 +66,7 @@ akka-http-routes-dispatcher {
 }
 
 dao-dispatcher {
+  # these are the default dispatcher settings
   type = "Dispatcher"
   executor = "fork-join-executor"
 
@@ -75,6 +81,7 @@ dao-dispatcher {
 
 
 service-dispatcher {
+  # these are the default dispatcher settings
   type = "Dispatcher"
   executor = "fork-join-executor"
 

--- a/backend/src/main/resources/reference.conf
+++ b/backend/src/main/resources/reference.conf
@@ -3,12 +3,14 @@ bootzooka {
 
   db {
     h2 {
+      queueSize = -1
       dataSourceClass = "org.h2.jdbcx.JdbcDataSource"
       properties = {
         url = "jdbc:h2:file:./data/bootzooka"
       }
     }
     postgres {
+      queueSize = -1
       dataSourceClass = "org.postgresql.ds.PGSimpleDataSource"
       maxConnections = 16
       properties = {

--- a/backend/src/main/resources/reference.conf
+++ b/backend/src/main/resources/reference.conf
@@ -46,3 +46,43 @@ akka.http.session {
   server-secret = "d07ll3lesrinf39t7mc5h6un6r0c69lgfno69dsak4vabeqamouq4328cuaekros401ajdpkh61aatpd8ro24rbuqmgtnd1ebag6ljnb65i8a55d482ok7o0nch0bfbe"
   server-secret = ${?SERVER_SECRET}
 }
+
+akka-http-routes-dispatcher {
+  type = "Dispatcher"
+  executor = "fork-join-executor"
+
+  fork-join-executor {
+    parallelism-min = 8
+    parallelism-factor = 3.0
+    parallelism-max = 64
+  }
+
+  throughput = 5
+}
+
+dao-dispatcher {
+  type = "Dispatcher"
+  executor = "fork-join-executor"
+
+  fork-join-executor {
+    parallelism-min = 8
+    parallelism-factor = 3.0
+    parallelism-max = 64
+  }
+
+  throughput = 5
+}
+
+
+service-dispatcher {
+  type = "Dispatcher"
+  executor = "fork-join-executor"
+
+  fork-join-executor {
+    parallelism-min = 8
+    parallelism-factor = 3.0
+    parallelism-max = 64
+  }
+
+  throughput = 5
+}

--- a/backend/src/main/scala/com/softwaremill/bootzooka/Beans.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/Beans.scala
@@ -10,8 +10,6 @@ import com.softwaremill.bootzooka.user.{UserDao, UserService}
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 
-import scala.concurrent.ExecutionContext
-
 trait Beans extends StrictLogging {
   def system: ActorSystem
 

--- a/backend/src/main/scala/com/softwaremill/bootzooka/Main.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/Main.scala
@@ -23,6 +23,7 @@ class Main() extends StrictLogging {
     import _system.dispatcher
 
     val modules = new Beans with Routes {
+
       lazy val sessionConfig = SessionConfig.fromConfig(config.rootConfig).copy(sessionEncryptData = true)
 
       implicit lazy val ec = _system.dispatcher

--- a/backend/src/main/scala/com/softwaremill/bootzooka/Main.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/Main.scala
@@ -26,7 +26,7 @@ class Main() extends StrictLogging {
 
       lazy val sessionConfig = SessionConfig.fromConfig(config.rootConfig).copy(sessionEncryptData = true)
 
-      implicit lazy val ec = _system.dispatchers.lookup("akka-http-routes")
+      implicit lazy val ec = _system.dispatchers.lookup("akka-http-routes-dispatcher")
       implicit lazy val sessionManager: SessionManager[Session] = new SessionManager[Session](sessionConfig)
       implicit lazy val materializer = _materializer
       lazy val system = _system

--- a/backend/src/main/scala/com/softwaremill/bootzooka/Main.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/Main.scala
@@ -26,7 +26,7 @@ class Main() extends StrictLogging {
 
       lazy val sessionConfig = SessionConfig.fromConfig(config.rootConfig).copy(sessionEncryptData = true)
 
-      implicit lazy val ec = _system.dispatcher
+      implicit lazy val ec = _system.dispatchers.lookup("akka-http-routes")
       implicit lazy val sessionManager: SessionManager[Session] = new SessionManager[Session](sessionConfig)
       implicit lazy val materializer = _materializer
       lazy val system = _system


### PR DESCRIPTION
Some of the best practices I've found for trying to optimize throughput.
- Bulkhead dispatchers based on layers (probably should be by feature also)
- Async Logging
- Don't use default system dispatcher
- Allow slick to use unbounded queue (not threads) (-1 is probably not good for production but for throughput tests is nice to see where the breaking point is)
- Match the Slick thread pool size to the number of Postgres connections

Tests all pass.
I didn't run the gatling test as I'm not really interested in setting up npm, postgres, gattling etc so I'll leave it to you to see if these make sense to you to try out.

Context: This was inspired to get more throughput with akka-http after reading the very excellent [bootzooka-akka-http-vs-scalatra blog article](https://hanskoff.github.io/bootzooka-akka-http-vs-scalatra.html)  by @hanskoff 