### PR TITLE
Add security related HTTP headers

### DIFF
--- a/backend/src/main/scala/com/softwaremill/bootzooka/api/RoutesSupport.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/api/RoutesSupport.scala
@@ -2,19 +2,23 @@ package com.softwaremill.bootzooka.api
 
 import akka.http.scaladsl.marshalling._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.CacheDirectives.{`max-age`, `must-revalidate`, `no-cache`, `no-store`, `public`}
-import akka.http.scaladsl.model.headers.{`Cache-Control`, `Expires`, `Last-Modified`}
+import akka.http.scaladsl.model.headers.CacheDirectives._
+import akka.http.scaladsl.model.headers.{`Cache-Control`, `Last-Modified`, _}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{AuthorizationFailedRejection, Directive1}
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 import akka.stream.Materializer
+import cats.data.Xor
+import com.softwaremill.bootzooka.http.model.headers.`X-Content-Type-Options`.`nosniff`
+import com.softwaremill.bootzooka.http.model.headers.`X-Frame-Options`.`DENY`
+import com.softwaremill.bootzooka.http.model.headers.`X-XSS-Protection`.`1; mode=block`
+import com.softwaremill.bootzooka.http.model.headers.{`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`}
 import com.softwaremill.bootzooka.user.{BasicUserData, Session, UserId, UserService}
 import com.softwaremill.session.SessionDirectives._
+import com.softwaremill.session.SessionOptions._
 import com.softwaremill.session.{RefreshTokenStorage, SessionManager}
-import cats.data.Xor
 import io.circe._
 import io.circe.jawn.decode
-import com.softwaremill.session.SessionOptions._
 
 import scala.concurrent.ExecutionContext
 
@@ -100,4 +104,12 @@ trait CacheSupport {
   val cacheImages =
     extensionsTest("png", "svg", "gif", "woff", "jpg").flatMap { _ => cacheResponse } |
       doNotCacheResponse
+}
+
+trait SecuritySupport {
+  val addSecurityHeaders = respondWithHeaders(
+    `X-Frame-Options`(`DENY`),
+    `X-Content-Type-Options`(`nosniff`),
+    `X-XSS-Protection`(`1; mode=block`)
+  )
 }

--- a/backend/src/main/scala/com/softwaremill/bootzooka/http/model/headers/headers.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/http/model/headers/headers.scala
@@ -1,0 +1,86 @@
+package com.softwaremill.bootzooka.http.model.headers
+
+import akka.http.scaladsl.model.headers.{ModeledCustomHeader, ModeledCustomHeaderCompanion}
+
+import scala.util.Try
+
+private[headers] sealed trait HeaderDirective[H] {
+  def value: String
+}
+
+private[headers] sealed trait RequestHeaderDirective[H] extends HeaderDirective[H]
+
+private[headers] sealed trait ResponseHeaderDirective[H] extends HeaderDirective[H]
+
+// https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+// https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet
+object `X-Frame-Options` extends ModeledCustomHeaderCompanion[`X-Frame-Options`] {
+  override val name = "X-Frame-Options"
+
+  override def parse(value: String) = Try(new `X-Frame-Options`(value))
+
+  def apply(value: ResponseHeaderDirective[`X-Frame-Options`]) = new `X-Frame-Options`(value.value)
+
+  case object `DENY` extends ResponseHeaderDirective[`X-Frame-Options`] {
+    override def value: String = "DENY"
+  }
+
+  case object `SAMEORIGIN` extends ResponseHeaderDirective[`X-Frame-Options`] {
+    override def value: String = "SAMEORIGIN"
+  }
+
+  final case class `ALLOW-FROM`(uri: String) extends ResponseHeaderDirective[`X-Frame-Options`] {
+    override def value: String = s"ALLOW-FROM $uri"
+  }
+}
+
+final case class `X-Frame-Options`(value: String) extends ModeledCustomHeader[`X-Frame-Options`] {
+  override def renderInRequests = false
+  override def renderInResponses = true
+  override val companion = `X-Frame-Options`
+}
+
+object `X-Content-Type-Options` extends ModeledCustomHeaderCompanion[`X-Content-Type-Options`] {
+  override val name = "X-Content-Type-Options"
+
+  override def parse(value: String) = Try(new `X-Content-Type-Options`(value))
+
+  def apply(value: ResponseHeaderDirective[`X-Content-Type-Options`]) = new `X-Content-Type-Options`(value.value)
+
+  case object `nosniff` extends ResponseHeaderDirective[`X-Content-Type-Options`] {
+    override def value: String = "nosniff"
+  }
+}
+
+final case class `X-Content-Type-Options`(value: String) extends ModeledCustomHeader[`X-Content-Type-Options`] {
+  override def renderInRequests = false
+  override def renderInResponses = true
+  override val companion = `X-Content-Type-Options`
+}
+
+object `X-XSS-Protection` extends ModeledCustomHeaderCompanion[`X-XSS-Protection`] {
+  override val name = "X-XSS-Protection"
+
+  override def parse(value: String) = Try(new `X-XSS-Protection`(value))
+
+  def apply(value: ResponseHeaderDirective[`X-XSS-Protection`]) = new `X-XSS-Protection`(value.value)
+
+  case object `0` extends ResponseHeaderDirective[`X-XSS-Protection`] {
+    override def value: String = "0"
+  }
+
+  case object `1; mode=block` extends ResponseHeaderDirective[`X-XSS-Protection`] {
+    override def value: String = "1; mode=block"
+  }
+
+  final case class `1; report=`(uri: String) extends ResponseHeaderDirective[`X-XSS-Protection`] {
+    override def value: String = s"1; report=$uri"
+  }
+}
+
+final case class `X-XSS-Protection`(value: String) extends ModeledCustomHeader[`X-XSS-Protection`] {
+  override def renderInRequests = false
+  override def renderInResponses = true
+  override val companion = `X-XSS-Protection`
+}
+

--- a/backend/src/test/scala/com/softwaremill/bootzooka/routes/RoutesBaseSpec.scala
+++ b/backend/src/test/scala/com/softwaremill/bootzooka/routes/RoutesBaseSpec.scala
@@ -1,0 +1,27 @@
+package com.softwaremill.bootzooka.routes
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.softwaremill.bootzooka.api.RoutesBase
+import com.softwaremill.bootzooka.http.model.headers.`X-Content-Type-Options`.`nosniff`
+import com.softwaremill.bootzooka.http.model.headers.`X-Frame-Options`.`DENY`
+import com.softwaremill.bootzooka.http.model.headers.`X-XSS-Protection`.`1; mode=block`
+import com.softwaremill.bootzooka.http.model.headers.{`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`}
+import org.scalatest.{FlatSpec, Matchers}
+
+class RoutesBaseSpec extends FlatSpec with Matchers with ScalatestRouteTest {
+
+  it should "return a response wirth security headers" in {
+    val routes = new RoutesBase {}.base {
+      get {
+        complete("ok")
+      }
+    }
+
+    Get() ~> routes ~> check {
+      response.header[`X-Frame-Options`].get shouldBe `X-Frame-Options`(`DENY`)
+      response.header[`X-Content-Type-Options`].get shouldBe `X-Content-Type-Options`(`nosniff`)
+      response.header[`X-XSS-Protection`].get shouldBe `X-XSS-Protection`(`1; mode=block`)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val scalaLoggingVersion = "3.1.0"
 val slickVersion = "3.1.1"
 val seleniumVersion = "2.53.0"
 val circeVersion = "0.4.0"
-val akkaVersion = "2.4.3"
+val akkaVersion = "2.4.4"
 
 val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion
 val logBackClassic = "ch.qos.logback" % "logback-classic" % logBackVersion
@@ -83,7 +83,6 @@ def npmTask(taskName: String) = (baseDirectory, streams) map { (bd, s) =>
   println("Building with Webpack : " + taskName)
   haltOnCmdResultError(buildWebpack())
 } dependsOn updateNpm
-
 
 lazy val rootProject = (project in file("."))
   .settings(commonSettings: _*)


### PR DESCRIPTION
I've added 3 headers from [OWASP recomendations]:(https://www.owasp.org/index.php/List_of_useful_HTTP_headers)

Here is the main piece of code:
```
trait SecuritySupport {
  val addSecurityHeaders = respondWithHeaders(
    `X-Frame-Options`(`DENY`),
    `X-Content-Type-Options`(`nosniff`),
    `X-XSS-Protection`(`1; mode=block`)
  )
}
```