### PR TITLE
Fix missing autoprefixer dependency

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "angular-mocks": "~1.5.0",
+    "autoprefixer": "^6.3.6",
     "babel-core": "^6.4.5",
     "babel-loader": "^6.2.1",
     "babel-plugin-add-module-exports": "^0.1.2",


### PR DESCRIPTION
I had to add this dependency for the `npm start` to work the first time.

You should be able to reproduce by (**deletes files!**):
```
$ git clean -fxd -e .idea
$ ./frontend-start.sh
```