### PR TITLE
Adopt AdoptOpenJDK 🙂

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val fatJarSettings = Seq(
 
 lazy val dockerSettings = Seq(
   dockerExposedPorts := Seq(8080),
-  dockerBaseImage := "openjdk:8u212-jdk-stretch",
+  dockerBaseImage := "adoptopenjdk:8u232-b09-jdk-hotspot",
   packageName in Docker := "bootzooka",
   dockerUsername := Some("softwaremill"),
   dockerCommands := {

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val fatJarSettings = Seq(
 
 lazy val dockerSettings = Seq(
   dockerExposedPorts := Seq(8080),
-  dockerBaseImage := "adoptopenjdk:8u232-b09-jdk-hotspot",
+  dockerBaseImage := "adoptopenjdk:11.0.5_10-jdk-hotspot",
   packageName in Docker := "bootzooka",
   dockerUsername := Some("softwaremill"),
   dockerCommands := {


### PR DESCRIPTION
One advantage is the reduction of the size of the image (even if it's not a good enough argument to make me use Alpine based images). See:

<img width="825" alt="Screenshot 2019-11-16 18 28 47" src="https://user-images.githubusercontent.com/1193670/68989779-8573c300-089f-11ea-9c6b-aefdfa5fd75e.png">

where `bootzooka` is the build with AdoptOpenJDK and `bootzooka-old` is the build with the OpenJDK image.

There are a lot of arguments to choose AdoptOpenJDK but maybe the right arguments are that it's a community build et that they're always more up-to-date than the OpenJDK build.

LMKWYT 