### PR TITLE
Add organization to docker image name in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   bootzooka:
-    image: 'bootzooka:latest'
+    image: 'softwaremill/bootzooka:latest'
     ports:
       - '8080:8080'
     depends_on:


### PR DESCRIPTION
`sbt docker:publishLocal` builds image with name `softwaremill/bootzooka:latest`, but docker-compose trys to use `bootzooka:latest` image.

This PR contains fix to avoid error when user trys to up server using `docker-compose up`.
