### PR TITLE
Fix timestamp generated by now()

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ def haltOnCmdResultError(result: Int) {
 def now(): String = {
   import java.text.SimpleDateFormat
   import java.util.Date
-  new SimpleDateFormat("yyyy-mm-dd-hhmmss").format(new Date())
+  new SimpleDateFormat("yyyy-MM-dd-hhmmss").format(new Date())
 }
 
 lazy val rootProject = (project in file("."))


### PR DESCRIPTION
now() in `build.sbt` outputs dates as Year-Minutes-Day instead of Year-Month-Day.