### PR TITLE
Changed the default fonts, also the color to a darker one.

### DIFF
--- a/docs/stylesheets/styles.css
+++ b/docs/stylesheets/styles.css
@@ -2,8 +2,10 @@
 
 body {
   padding:50px;
-  font:14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color:#777;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgb(23, 23, 23);
   font-weight:300;
 }
 
@@ -58,9 +60,9 @@ blockquote {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, sans-serif;
   color:#333;
-  font-size:12px;
+  font-size:13px;
 }
 
 pre {


### PR DESCRIPTION
Hi,

I created this pull request in order to change the color of the fonts on the documentation side. Imo, the text is too washed out. Other docs sites use darker text colors. See: https://http4s.org/v0.21/ or https://docs.microsoft.com/en-ca/dotnet/standard/security/ (sorry for sending you to a Microsoft site, it's only for the purpose of checking the text color/font :-) ).

I checked the site locally using jekyll on macos, windows 10 (IE edge), ipad IOS 13, android 9 - it looks good imo.

Please take a look, review it and if you like, merge it.
