### PR TITLE
Changes in Bootzooka GH actions

### DIFF
--- a/.github/workflows/bootzooka-ci.yml
+++ b/.github/workflows/bootzooka-ci.yml
@@ -1,0 +1,45 @@
+name: Bootzooka CI
+
+on:
+  pull_request:
+  push:
+    tags: [v*]
+    branches:
+      - master
+    paths-ignore:
+      - "helm/**"
+  release:
+    types:
+      - released
+    paths-ignore:
+      - "helm/**"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Check-out repository
+      id: repo-checkout
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      id: jdk-setup
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Cache SBT
+      id: cache-sbt
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.sbt
+          ~/.ivy2/cache
+          ~/.coursier
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+    - name: Run tests
+      id: run-tests
+      run: sbt test

--- a/.github/workflows/bootzooka-deploy.yml
+++ b/.github/workflows/bootzooka-deploy.yml
@@ -1,7 +1,6 @@
-name: Bootzooka CI
+name: Bootzooka Deploy
 
 on:
-  pull_request:
   push:
     tags: [v*]
     branches:
@@ -15,37 +14,8 @@ on:
       - "helm/**"
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-18.04
-
-    steps:
-    - name: Check-out repository
-      id: repo-checkout
-      uses: actions/checkout@v2
-
-    - name: Set up JDK 11
-      id: jdk-setup
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-
-    - name: Cache SBT
-      id: cache-sbt
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.sbt
-          ~/.ivy2/cache
-          ~/.coursier
-        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-
-    - name: Run tests
-      id: run-tests
-      run: sbt test
-
   deploy:
-    if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: [ test ]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Split Bootzooka CI action into two separate actions as for now deploy job was always skipped and mergify mark whole action as unsuccessful.