### PR TITLE
Update DefaultClock.scala to fix time generation

### DIFF
--- a/backend/src/main/scala/com/softwaremill/bootzooka/util/DefaultClock.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/util/DefaultClock.scala
@@ -9,7 +9,7 @@ object DefaultClock extends Clock {
 
   override def now[F[_]: Sync](): F[Instant] = {
     for {
-      now <- CatsClock[F].realTime.map(_.length)
+      now <- CatsClock[F].realTime.map(_.toMillis)
       instant = Instant.ofEpochMilli(now)
     } yield instant
   }


### PR DESCRIPTION
fix the time.

using .length led to dates into future:

55451-02-11 00:16:41.323+00

using .toMillis returns correct dates