### PR TITLE
Add X-Frame-Options and Content-Security-Policy headers

### DIFF
--- a/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
@@ -8,6 +8,7 @@ import com.softwaremill.bootzooka.logging.FLogging
 import com.softwaremill.bootzooka.util.{Id, SecureRandomId}
 import com.softwaremill.tagging._
 import io.circe.Printer
+import sttp.model.HeaderNames.XFrameOptions
 import sttp.model.StatusCode
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.generic.auto.SchemaDerivation
@@ -27,7 +28,7 @@ class Http() extends Tapir with TapirJsonCirce with TapirSchemas with FLogging {
     */
   val baseEndpoint: PublicEndpoint[Unit, (StatusCode, Error_OUT), Unit, Any] =
     endpoint.errorOut(failOutput)
-      .out(header("X-Frame-Options", "SAMEORIGIN"))
+      .out(header(XFrameOptions, "SAMEORIGIN"))
 
   /** Base endpoint description for secured endpoints. Specifies that errors are always returned as JSON values corresponding to the
     * [[Error_OUT]] class, and that authentication is read from the `Authorization: Bearer` header.

--- a/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
@@ -28,6 +28,7 @@ class Http() extends Tapir with TapirJsonCirce with TapirSchemas with FLogging {
     */
   val baseEndpoint: PublicEndpoint[Unit, (StatusCode, Error_OUT), Unit, Any] =
     endpoint.errorOut(failOutput)
+      // Prevent clickjacking attacks: https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html
       .out(header("X-Frame-Options", "DENY"))
       .out(header("Content-Security-Policy", "frame-ancestors 'none'"))
 

--- a/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
@@ -27,6 +27,7 @@ class Http() extends Tapir with TapirJsonCirce with TapirSchemas with FLogging {
     */
   val baseEndpoint: PublicEndpoint[Unit, (StatusCode, Error_OUT), Unit, Any] =
     endpoint.errorOut(failOutput)
+      .out(header("X-Frame-Options", "SAMEORIGIN"))
 
   /** Base endpoint description for secured endpoints. Specifies that errors are always returned as JSON values corresponding to the
     * [[Error_OUT]] class, and that authentication is read from the `Authorization: Bearer` header.

--- a/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/http/Http.scala
@@ -28,7 +28,8 @@ class Http() extends Tapir with TapirJsonCirce with TapirSchemas with FLogging {
     */
   val baseEndpoint: PublicEndpoint[Unit, (StatusCode, Error_OUT), Unit, Any] =
     endpoint.errorOut(failOutput)
-      .out(header(XFrameOptions, "SAMEORIGIN"))
+      .out(header("X-Frame-Options", "DENY"))
+      .out(header("Content-Security-Policy", "frame-ancestors 'none'"))
 
   /** Base endpoint description for secured endpoints. Specifies that errors are always returned as JSON values corresponding to the
     * [[Error_OUT]] class, and that authentication is read from the `Authorization: Bearer` header.


### PR DESCRIPTION
This PR adds `X-Frame-Options` and `Content-Security-Policy` headers preventing clickjacking.

`X-Frame-Options` has been deprecated by `Content-Security-Policy`, but it is recommended to use both headers in order to support old browsers.

Source: https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html