### PR TITLE
CI: Fix Helm Chart Publish Stage - Bump Postgres Chart to 16

### DIFF
--- a/helm/bootzooka/Chart.yaml
+++ b/helm/bootzooka/Chart.yaml
@@ -21,7 +21,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/softwaremill/bootzooka/master/banner.png
 dependencies:
  - name: postgresql
-   version: ^9
+   version: ^16
    repository: https://charts.bitnami.com/bitnami
    condition: postgresql.enabled
 annotations:


### PR DESCRIPTION
Bitnami has removed previously used PostgreSQL Helm Chart. Bumping current version to latest available major version (with Postgres 17).