### PR TITLE
Bump helm-gh-pages action to 1.7.0

### DIFF
--- a/.github/workflows/bootzooka-helm-ci.yaml
+++ b/.github/workflows/bootzooka-helm-ci.yaml
@@ -144,5 +144,5 @@ jobs:
           charts_url: https://softwaremill.github.io/sml-helm-public-repo
           owner: softwaremill
           repository: sml-helm-public-repo
-          helm_version: 3.7.1
+          helm_version: 3.10.0
           linting: off

--- a/.github/workflows/bootzooka-helm-ci.yaml
+++ b/.github/workflows/bootzooka-helm-ci.yaml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Publish Helm Chart
         id: helm-publish-chart
-        uses: stefanprodan/helm-gh-pages@v1.2.0
+        uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
           token: ${{ secrets.CR_TOKEN }}
           charts_dir: helm


### PR DESCRIPTION
New Postgres Bitnami Chart uses OCI-based registry that requires Helm `>=v3.8.0`. Bumping the `helm-gh-pages` action to `v1.7.0` should result in Helm `v3.10.0`.