### PR TITLE
Print opentelemetry configuration on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ SQL_PASSWORD=bootzooka ./backend-start.sh
 ```
 
 By default, OpenTelemetry is disabled to avoid telemetry export exceptions (which is available and explorable if you are
-using the Docker compose setup). If you have a collector running, edit the startp script appropriately.
+using the Docker compose setup). If you have a collector running, edit the startup script appropriately.
 
 The backend will start on [`http://localhost:8080`](http://localhost:8080). You can explore the API docs using the
 Swagger UI by navigating to [`http://localhost:8080/api/v1/docs`](http://localhost:8080/api/v1/docs).

--- a/backend-start.sh
+++ b/backend-start.sh
@@ -6,4 +6,6 @@ export OTEL_SDK_DISABLED=true
 # Bootzooka uses the OTLP/HTTP protocol to export metrics (see the observabilityDependencies in build.sbt)
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
+export OTEL_SERVICE_NAME=bootzooka
+
 sbt "~backend/reStart"

--- a/backend/src/main/scala/com/softwaremill/bootzooka/Dependencies.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/Dependencies.scala
@@ -6,6 +6,7 @@ import com.softwaremill.bootzooka.email.EmailService
 import com.softwaremill.bootzooka.email.sender.EmailSender
 import com.softwaremill.bootzooka.http.{HttpApi, HttpConfig}
 import com.softwaremill.bootzooka.infrastructure.DB
+import com.softwaremill.bootzooka.logging.Logging
 import com.softwaremill.bootzooka.metrics.Metrics
 import com.softwaremill.bootzooka.passwordreset.{PasswordResetApi, PasswordResetAuthToken}
 import com.softwaremill.bootzooka.security.{ApiKeyAuthToken, ApiKeyService, Auth}
@@ -15,17 +16,20 @@ import com.softwaremill.macwire.{autowire, autowireMembersOf}
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender
 import io.opentelemetry.instrumentation.runtimemetrics.java17.RuntimeMetrics
+import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
-import ox.{Ox, discard, tap, useCloseableInScope, useInScope}
+import ox.*
 import sttp.client4.SyncBackend
 import sttp.client4.httpclient.HttpClientSyncBackend
 import sttp.client4.logging.slf4j.Slf4jLoggingBackend
 import sttp.client4.opentelemetry.{OpenTelemetryMetricsBackend, OpenTelemetryTracingBackend}
 import sttp.tapir.AnyEndpoint
 
+import scala.jdk.CollectionConverters.*
+
 case class Dependencies(httpApi: HttpApi, emailService: EmailService)
 
-object Dependencies:
+object Dependencies extends Logging:
   val endpointsForDocs: List[AnyEndpoint] = List(UserApi, PasswordResetApi, VersionApi).flatMap(_.endpointsForDocs)
 
   private case class Apis(userApi: UserApi, passwordResetApi: PasswordResetApi, versionApi: VersionApi):
@@ -60,9 +64,30 @@ object Dependencies:
     )
 
   private def initializeOtel(): OpenTelemetry =
-    AutoConfiguredOpenTelemetrySdk
-      .initialize()
-      .getOpenTelemetrySdk()
+    val sdk = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+    logOtel()
+    sdk
       .tap(otel => RuntimeMetrics.create(otel).discard)
       .tap(OpenTelemetryAppender.install)
+
+  private def logOtel(): Unit =
+    def render(overrides: Seq[(String, String)]): String =
+      if overrides.isEmpty then ""
+      else "Overrides:\n" + overrides.sortBy(_._1).map((k, v) => s"$k=$v").mkString("\n")
+
+    val overrides =
+      System.getenv.asScala.toSeq.filter((k, _) => k.startsWith("OTEL_")) ++ sys.props.toSeq.filter((k, _) => k.startsWith("otel."))
+
+    val message = if overrides.isEmpty then "No configuration overrides" else render(overrides)
+
+    logger.info(
+      s"""
+         |OpenTelemetry configuration:
+         |-----------------------
+         |$message
+         |For defaults refer to https://opentelemetry.io/docs/languages/java/configuration/
+         |""".stripMargin
+    )
+  end logOtel
+
 end Dependencies

--- a/backend/src/main/scala/com/softwaremill/bootzooka/Dependencies.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/Dependencies.scala
@@ -64,9 +64,10 @@ object Dependencies extends Logging:
     )
 
   private def initializeOtel(): OpenTelemetry =
-    val sdk = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
     logOtel()
-    sdk
+    AutoConfiguredOpenTelemetrySdk
+      .initialize()
+      .getOpenTelemetrySdk
       .tap(otel => RuntimeMetrics.create(otel).discard)
       .tap(OpenTelemetryAppender.install)
 

--- a/backend/src/main/scala/com/softwaremill/bootzooka/config/Config.scala
+++ b/backend/src/main/scala/com/softwaremill/bootzooka/config/Config.scala
@@ -27,7 +27,7 @@ object Config extends Logging:
                       |User:           ${config.user}
                       |
                       |Build & env info:
-                      |-----------------
+                      |-----------------------
                       |""".stripMargin
 
     val info = TreeMap(BuildInfo.toMap.toSeq*).foldLeft(baseInfo) { case (str, (k, v)) =>

--- a/build.sbt
+++ b/build.sbt
@@ -28,9 +28,9 @@ val httpDependencies = Seq(
 )
 
 val observabilityDependencies = Seq(
-  "com.softwaremill.sttp.client4" %% "opentelemetry-backend" % sttpVersion, // OTEL <-> sttp integation
-  "com.softwaremill.sttp.tapir" %% "tapir-opentelemetry-metrics" % tapirVersion, // OTEL <-> Tapir integation
-  "com.softwaremill.sttp.tapir" %% "tapir-opentelemetry-tracing" % tapirVersion, // OTEL <-> Tapir integation
+  "com.softwaremill.sttp.client4" %% "opentelemetry-backend" % sttpVersion, // OTEL <-> sttp integration
+  "com.softwaremill.sttp.tapir" %% "tapir-opentelemetry-metrics" % tapirVersion, // OTEL <-> Tapir integration
+  "com.softwaremill.sttp.tapir" %% "tapir-opentelemetry-tracing" % tapirVersion, // OTEL <-> Tapir integration
   "com.softwaremill.ox" %% "otel-context" % oxVersion, // OTEL context propagation in Ox scopes
   "io.opentelemetry" % "opentelemetry-exporter-otlp" % otelVersion exclude ("io.opentelemetry", "opentelemetry-exporter-sender-okhttp"),
   "io.opentelemetry" % "opentelemetry-exporter-sender-jdk" % otelVersion,
@@ -41,7 +41,7 @@ val observabilityDependencies = Seq(
 
 val jsonDependencies = Seq(
   "com.softwaremill.sttp.client4" %% "jsoniter" % sttpVersion, // main JSON library
-  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % tapirVersion, // Tapir <-> jsoniter integation
+  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % tapirVersion, // Tapir <-> jsoniter integration
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.38.9" // automatic codec derivation
 )
 

--- a/ui/src/api/apiContext.ts
+++ b/ui/src/api/apiContext.ts
@@ -1,7 +1,7 @@
 import {
   skipToken,
   type DefaultError,
-  type Enabled,
+  type QueryBooleanOption,
   type QueryKey,
   type UseQueryOptions,
 } from '@tanstack/react-query';
@@ -28,7 +28,7 @@ export type ApiContext<
      * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
      * Defaults to `true`.
      */
-    enabled?: Enabled<TQueryFnData, TError, TQueryFnData, TQueryKey>;
+    enabled?: QueryBooleanOption<TQueryFnData, TError, TQueryFnData, TQueryKey>;
   };
 };
 


### PR DESCRIPTION
What sounded simple turned out to be tricky. Opentelemetry SDK doesn't expose accessor methods for config. An internal `AutoConfigureUtil` allows to access the `config` instance with reflection but I'd rather don't rely on unstable, internal API in bootzooka; additionally the `config` object will only have non null values for config that is resolved from env vars or system properties, in other words it doesn't expose defaults.

Related issue https://github.com/open-telemetry/opentelemetry-java/issues/6935. 

DONE: 
* print out env and system properties overrides and a link to documentation containing all defaults that may apply