### PR TITLE
Fix UI build: type `process` in tsconfig (unblocks all dependabot PRs)

### DIFF
--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "node"],
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,


### PR DESCRIPTION
## Problem

CI (`verify` job) is red on **every** open dependency-update PR. The failure is **not** caused by the bumped dependencies — it's a latent breakage on `master` itself. Reproduced on `master` HEAD:

```
src/api/apiFetcher.ts(5,17): error TS2591: Cannot find name 'process'.
  Do you need to install type definitions for node? ...
error Command failed with exit code 2.
```

`apiFetcher.ts` reads `process.env.REACT_APP_BASE_URL` (substituted at bundle time by Vite's `define`). `tsc -b` still needs `process` to be typed.

## Root cause

`ui/tsconfig.app.json` pins `"types": ["vitest/globals"]`, which restricts global type resolution to that single package. Under **vitest 3**, `vitest/globals` transitively pulled in Node globals, so `process` was typed and the build passed (last green master CI: 2026-05-29). The recent **vitest 3 → 4** bump (#2949, #2956) dropped that transitive node typing, exposing the gap. `@types/node` is already a dependency but wasn't being loaded because of the `types` override.

## Fix

Add `"node"` to the `types` array so `@types/node` is loaded and `process` is typed again — exactly what the compiler error suggests.

## Verification

```
$ npx tsc -b      # exit 0
$ npx vite build  # exit 0 (built dist/)
```

Once merged, the open dependabot PRs will rebase onto this and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)