### PR TITLE
Bump react-dom to 19.2.8 to match react

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.8",
     "react-router": "^8.2.0",
-    "react-dom": "^19.2.7",
+    "react-dom": "^19.2.8",
     "react-hook-form": "^7.82.0",
     "react-icons": "^5.7.0",
     "sonner": "^2.0.7",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3802,10 +3802,10 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-react-dom@^19.2.7:
-  version "19.2.7"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.7.tgz#0450dc9ae9ddbff76ef196401cd8b8c7fb466ccc"
-  integrity sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==
+react-dom@^19.2.8:
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.8.tgz#3b46b9eeda877cdff2cf13d2770fff4ae36c2ec2"
+  integrity sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==
   dependencies:
     scheduler "^0.27.0"
 


### PR DESCRIPTION
Fixes the red `verify` check on master and on every open PR.

#3221 bumped `react` 19.2.7 → 19.2.8 but left `react-dom` at 19.2.7. React refuses to initialise when the two differ:

```
Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
  - react:      19.2.8
  - react-dom:  19.2.7
```

All 16 vitest suites fail on import, so master has been red since #3221 merged (its own `verify` check was already failing at merge time).

Verified locally under Node 24 (the version CI uses): 16 test files, 34 tests, all passing.